### PR TITLE
Update s3prl.py

### DIFF
--- a/espnet2/asr/frontend/s3prl.py
+++ b/espnet2/asr/frontend/s3prl.py
@@ -52,12 +52,12 @@ class S3prlFrontend(AbsFrontend):
         )
         upstream.eval()
         if getattr(
-            upstream, "model", None
-        ) is not None and upstream.model.__class__.__name__ in [
+            upstream.upstream, "model", None
+        ) is not None and upstream.upstream.model.__class__.__name__ in [
             "Wav2Vec2Model",
             "HubertModel",
         ]:
-            upstream.model.encoder.layerdrop = 0.0
+            upstream.upstream.model.encoder.layerdrop = 0.0
 
         if layer != -1:
             layer_selections = [layer]


### PR DESCRIPTION
fix upstream attribute bug that interferes with layerdrop on Wav2vec2 and Hubert.  `upstream` has an attribute ` upstream` that acctually contains the `model` attribute